### PR TITLE
tacz_unidict-2.0.1Fork

### DIFF
--- a/src/main/java/com/scarasol/tud/data/AmmoData.java
+++ b/src/main/java/com/scarasol/tud/data/AmmoData.java
@@ -28,6 +28,14 @@ public class AmmoData implements JsonData, SearchableModData {
     private Float friction;
     private Float damage;
     private Float knockback;
+    private Integer bulletAmount;
+    private Float soundVolume;
+    private Float soundPitch;
+    private Boolean suppressSound;
+    private Float soundDistanceMultiplier;
+    private Float accuracyModifier;
+    private Float horizontalRecoilModifier;
+    private Float verticalRecoilModifier;
     private Boolean igniteEntity;
     private Boolean igniteBlock;
     private Integer igniteEntityTime;
@@ -121,6 +129,46 @@ public class AmmoData implements JsonData, SearchableModData {
     public void setKnockback(Float knockback) {
         this.knockback = knockback;
     }
+
+    public Integer getBulletAmount() {
+        return bulletAmount;
+    }
+
+    public void setBulletAmount(Integer bulletAmount) {
+        this.bulletAmount = bulletAmount;
+    }
+
+    public Float getSoundVolume() {
+        return soundVolume;
+    }
+
+    public Float getSoundPitch() {
+        return soundPitch;
+    }
+
+    public Boolean getSuppressSound() {
+        return suppressSound;
+    }
+
+    public Float getSoundDistanceMultiplier() {
+        return soundDistanceMultiplier;
+    }
+
+    public Float getAccuracyModifier() {
+        return accuracyModifier;
+    }
+
+    public void setAccuracyModifier(Float accuracyModifier) {
+        this.accuracyModifier = accuracyModifier;
+    }
+
+    public Float getHorizontalRecoilModifier() { return horizontalRecoilModifier; }
+
+    public void setHorizontalRecoilModifier(Float horizontalRecoilModifier) { this.horizontalRecoilModifier = horizontalRecoilModifier; }
+
+    public Float getVerticalRecoilModifier() { return verticalRecoilModifier; }
+
+    public void setVerticalRecoilModifier(Float verticalRecoilModifier) { this.verticalRecoilModifier = verticalRecoilModifier; }
 
     public Boolean getExplosion() {
         return explosion;

--- a/src/main/java/com/scarasol/tud/data/MagData.java
+++ b/src/main/java/com/scarasol/tud/data/MagData.java
@@ -2,5 +2,71 @@ package com.scarasol.tud.data;
 
 import net.minecraft.resources.ResourceLocation;
 
-public record MagData(ResourceLocation ammoId, Integer ammoAmount, Integer roundsPerMinute, Integer[] extendedMagAmmoAmount) {
+public class MagData {
+    private final ResourceLocation ammoId;
+    private final Integer ammoAmount;
+    private final Integer roundsPerMinute;
+    private final Integer[] extendedMagAmmoAmount;
+    private final boolean allowSuppress;
+    private final Float accuracyModifier;
+    private final Float horizontalRecoilModifier;
+    private final Float verticalRecoilModifier;
+    private final Float damageBonus;
+
+    public MagData(ResourceLocation ammoId, Integer ammoAmount, Integer roundsPerMinute, Integer[] extendedMagAmmoAmount) {
+        this(ammoId, ammoAmount, roundsPerMinute, extendedMagAmmoAmount, true);
+    }
+
+    public MagData(ResourceLocation ammoId, Integer ammoAmount, Integer roundsPerMinute,
+                   Integer[] extendedMagAmmoAmount, boolean allowSuppress) {
+        this(ammoId, ammoAmount, roundsPerMinute, extendedMagAmmoAmount, allowSuppress, 1.0f);
+    }
+
+    public MagData(ResourceLocation ammoId, Integer ammoAmount, Integer roundsPerMinute,
+                   Integer[] extendedMagAmmoAmount, boolean allowSuppress, Float accuracyModifier) {
+        this(ammoId, ammoAmount, roundsPerMinute, extendedMagAmmoAmount, allowSuppress, accuracyModifier, 1.0f, 1.0f);
+    }
+
+    public MagData(ResourceLocation ammoId, Integer ammoAmount, Integer roundsPerMinute,
+                   Integer[] extendedMagAmmoAmount, boolean allowSuppress, Float accuracyModifier,
+                   Float horizontalRecoilModifier, Float verticalRecoilModifier) {
+        this(ammoId, ammoAmount, roundsPerMinute, extendedMagAmmoAmount, allowSuppress,
+                accuracyModifier, horizontalRecoilModifier, verticalRecoilModifier, 0f);
+    }
+
+    public MagData(ResourceLocation ammoId, Integer ammoAmount, Integer roundsPerMinute,
+                   Integer[] extendedMagAmmoAmount, boolean allowSuppress, Float accuracyModifier,
+                   Float horizontalRecoilModifier, Float verticalRecoilModifier, Float damageBonus) {
+        this.ammoId = ammoId;
+        this.ammoAmount = ammoAmount;
+        this.roundsPerMinute = roundsPerMinute;
+        this.extendedMagAmmoAmount = extendedMagAmmoAmount;
+        this.allowSuppress = allowSuppress;
+        this.accuracyModifier = accuracyModifier;
+        this.horizontalRecoilModifier = horizontalRecoilModifier;
+        this.verticalRecoilModifier = verticalRecoilModifier;
+        this.damageBonus = damageBonus;
+    }
+
+    public ResourceLocation ammoId() { return ammoId; }
+    public Integer ammoAmount() { return ammoAmount; }
+    public Integer roundsPerMinute() { return roundsPerMinute; }
+    public Integer[] extendedMagAmmoAmount() { return extendedMagAmmoAmount; }
+    public boolean allowSuppress() { return allowSuppress; }
+
+    public float getAccuracyModifier() {
+        return accuracyModifier == null ? 1.0f : accuracyModifier;
+    }
+
+    public float getHorizontalRecoilModifier() {
+        return horizontalRecoilModifier == null ? 1.0f : horizontalRecoilModifier;
+    }
+
+    public float getVerticalRecoilModifier() {
+        return verticalRecoilModifier == null ? 1.0f : verticalRecoilModifier;
+    }
+
+    public float getDamageBonus() {
+        return damageBonus == null ? 0f : damageBonus;
+    }
 }

--- a/src/main/java/com/scarasol/tud/event/EventHandler.java
+++ b/src/main/java/com/scarasol/tud/event/EventHandler.java
@@ -7,6 +7,7 @@ import com.scarasol.tud.manager.AmmoManager;
 import com.scarasol.tud.util.data.DataManager;
 import com.scarasol.tud.util.io.ModGson;
 import com.tacz.guns.api.event.common.EntityHurtByGunEvent;
+import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.crafting.GunSmithTableRecipe;
 import com.tacz.guns.entity.EntityKineticBullet;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -16,7 +17,9 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -48,32 +51,39 @@ public class EventHandler {
 
     @SubscribeEvent
     public static void onEntityHurtByGunPost(EntityHurtByGunEvent.Pre event) {
-        if (event.getLogicalSide().isClient()) {
-            return;
-        }
-
+        if (event.getLogicalSide().isClient()) return;
         Entity hurt = event.getHurtEntity();
-        if (hurt == null) {
-            return;
-        }
-
+        if (hurt == null) return;
         Entity bullet = event.getBullet();
         String ammoId = bullet.getPersistentData().getString("TudAmmoId");
-
         AmmoData ammoData = DataManager.getSearchableModData(AmmoData.class, ammoId);
-        if (ammoData == null) {
-            return;
-        }
+        if (ammoData == null) return;
 
         String modifierId = ammoData.getModifierId();
-        if (modifierId == null) {
-            return;
+        if (modifierId != null) {
+            ModifierData modifierData = DataManager.getSearchableModData(ModifierData.class, modifierId);
+            if (modifierData != null) {
+                event.setBaseAmount((float) (event.getBaseAmount() * modifierData.getModifier(hurt)));
+            }
         }
-        ModifierData modifierData = DataManager.getSearchableModData(ModifierData.class, modifierId);
-        if (modifierData == null) {
-            return;
+
+        if (bullet instanceof Projectile projectile) {
+            Entity owner = projectile.getOwner();
+            if (owner instanceof LivingEntity shooter) {
+                ItemStack gunItem = shooter.getMainHandItem();
+                if (gunItem.getItem() instanceof IGun) {
+                    com.scarasol.tud.data.GunData gunData = AmmoManager.getGunData(gunItem);
+                    if (gunData != null) {
+                        MagData magData = gunData.getCurrentMag(gunItem);
+                        if (magData != null && magData.getDamageBonus() != 0f) {
+                            float newDamage = event.getBaseAmount() + magData.getDamageBonus();
+                            if (newDamage < 0) newDamage = 0;
+                            event.setBaseAmount(newDamage);
+                        }
+                    }
+                }
+            }
         }
-        event.setBaseAmount((float) (event.getBaseAmount() * modifierData.getModifier(hurt)));
     }
 
 

--- a/src/main/java/com/scarasol/tud/mixin/ClientGunTooltipMixin.java
+++ b/src/main/java/com/scarasol/tud/mixin/ClientGunTooltipMixin.java
@@ -2,12 +2,14 @@ package com.scarasol.tud.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.scarasol.tud.data.MagData;
 import com.scarasol.tud.inventory.tooltip.CustomGunTooltip;
 import com.scarasol.tud.manager.AmmoManager;
 import com.tacz.guns.api.item.IAmmo;
 import com.tacz.guns.client.tooltip.ClientGunTooltip;
 import com.tacz.guns.inventory.tooltip.GunTooltip;
 import com.tacz.guns.item.GunTooltipPart;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -71,6 +73,39 @@ public abstract class ClientGunTooltipMixin implements ClientTooltipComponent {
         com.scarasol.tud.data.AmmoData currentAmmoData = AmmoManager.getCurrentAmmoData(this.gun);
         if (currentAmmoData != null && currentAmmoData.getEntityId() != null) {
             this.hideDamageInfo = true;
+        }
+
+        if (!hideDamageInfo && currentAmmoData != null) {
+            Float totalDamage = currentAmmoData.getDamage();
+            Integer bulletAmount = currentAmmoData.getBulletAmount();
+            // 如果 bulletAmount 为 null，视为 1（单发）
+            int finalBulletAmount = (bulletAmount == null) ? 1 : bulletAmount;
+
+            if (totalDamage != null) {
+                // 获取枪械伤害修正值
+                com.scarasol.tud.data.GunData gunData = AmmoManager.getGunData(this.gun);
+                MagData magData = gunData != null ? gunData.getCurrentMag(this.gun) : null;
+                float damageBonus = magData != null ? magData.getDamageBonus() : 0f;
+
+                // 每发伤害 = (弹药总伤害 / 弹丸数) + 修正值
+                double perShotDamage = (totalDamage / finalBulletAmount) + damageBonus;
+                if (perShotDamage < 0) perShotDamage = 0;
+                String damageValue = String.format("%.1f", perShotDamage);
+
+                Component damageText;
+                if (finalBulletAmount > 1) {
+                    damageText = Component.translatable("tacz_unidict.tooltip.damage_per_projectile")
+                            .append(" ")
+                            .append(Component.literal(damageValue).withStyle(ChatFormatting.AQUA))
+                            .append(Component.literal(" x ").withStyle(ChatFormatting.AQUA))
+                            .append(Component.literal(String.valueOf(finalBulletAmount)).withStyle(ChatFormatting.AQUA));
+                } else {
+                    damageText = Component.translatable("tacz_unidict.tooltip.damage_single")
+                            .append(" ")
+                            .append(Component.literal(damageValue).withStyle(ChatFormatting.AQUA));
+                }
+                this.damage = damageText.copy();
+            }
         }
 
         if (this.hideDamageInfo) {

--- a/src/main/java/com/scarasol/tud/mixin/GunRecoilMixin.java
+++ b/src/main/java/com/scarasol/tud/mixin/GunRecoilMixin.java
@@ -1,0 +1,61 @@
+package com.scarasol.tud.mixin;
+
+import com.scarasol.tud.data.AmmoData;
+import com.scarasol.tud.data.MagData;
+import com.scarasol.tud.manager.AmmoManager;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.resource.pojo.data.gun.GunRecoil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(GunRecoil.class)
+public class GunRecoilMixin {
+
+    @ModifyVariable(method = "genPitchSplineFunction", at = @At("HEAD"), argsOnly = true, remap = false)
+    private float modifyPitchModifier(float modifier) {
+        return applyRecoilMultiplier(modifier, true);
+    }
+
+    @ModifyVariable(method = "genYawSplineFunction", at = @At("HEAD"), argsOnly = true, remap = false)
+    private float modifyYawModifier(float modifier) {
+        return applyRecoilMultiplier(modifier, false);
+    }
+
+    private float applyRecoilMultiplier(float originalModifier, boolean isPitch) {
+        Minecraft mc = Minecraft.getInstance();
+        Player player = mc.player;
+        if (player == null) return originalModifier;
+        ItemStack gunItem = player.getMainHandItem();
+        if (!(gunItem.getItem() instanceof IGun)) return originalModifier;
+
+        AmmoData ammoData = AmmoManager.getCurrentAmmoData(gunItem);
+        MagData magData = null;
+        com.scarasol.tud.data.GunData gunData = AmmoManager.getGunData(gunItem);
+        if (gunData != null) magData = gunData.getCurrentMag(gunItem);
+
+        float multiplier = 1.0f;
+        if (ammoData != null) {
+            if (isPitch) {
+                if (ammoData.getVerticalRecoilModifier() != null) multiplier *= ammoData.getVerticalRecoilModifier();
+            } else {
+                if (ammoData.getHorizontalRecoilModifier() != null) multiplier *= ammoData.getHorizontalRecoilModifier();
+            }
+        }
+        if (magData != null) {
+            if (isPitch) {
+                multiplier *= magData.getVerticalRecoilModifier();
+            } else {
+                multiplier *= magData.getHorizontalRecoilModifier();
+            }
+        }
+
+        if (Math.abs(multiplier - 1.0f) > 0.0001f) {
+            return originalModifier * multiplier;
+        }
+        return originalModifier;
+    }
+}

--- a/src/main/java/com/scarasol/tud/mixin/LocalPlayerShootMixin.java
+++ b/src/main/java/com/scarasol/tud/mixin/LocalPlayerShootMixin.java
@@ -1,0 +1,38 @@
+package com.scarasol.tud.mixin;
+
+import com.scarasol.tud.data.AmmoData;
+import com.scarasol.tud.data.GunData;
+import com.scarasol.tud.data.MagData;
+import com.scarasol.tud.manager.AmmoManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "com.tacz.guns.client.gameplay.LocalPlayerShoot")
+public class LocalPlayerShootMixin {
+
+    @Inject(method = "useSilenceSound", at = @At("HEAD"), cancellable = true, remap = false)
+    private void overrideSilenceSound(CallbackInfoReturnable<Boolean> cir) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return;
+
+        ItemStack mainHand = player.getMainHandItem();
+        GunData gunData = AmmoManager.getGunData(mainHand);
+        if (gunData != null) {
+            MagData magData = gunData.getCurrentMag(mainHand);
+            if (magData != null && !magData.allowSuppress()) {
+                cir.setReturnValue(false);
+                return;
+            }
+        }
+
+        AmmoData ammoData = AmmoManager.getCurrentAmmoData(mainHand);
+        if (ammoData != null && ammoData.getSuppressSound() != null) {
+            cir.setReturnValue(ammoData.getSuppressSound());
+        }
+    }
+}

--- a/src/main/java/com/scarasol/tud/mixin/SoundPlayManagerMixin.java
+++ b/src/main/java/com/scarasol/tud/mixin/SoundPlayManagerMixin.java
@@ -1,0 +1,104 @@
+package com.scarasol.tud.mixin;
+
+import com.scarasol.tud.data.AmmoData;
+import com.scarasol.tud.manager.AmmoManager;
+import com.tacz.guns.client.resource.GunDisplayInstance;
+import com.tacz.guns.client.sound.GunSoundInstance;
+import com.tacz.guns.config.common.GunConfig;
+import com.tacz.guns.init.ModSounds;
+import com.tacz.guns.resource.pojo.data.gun.GunData;
+import com.tacz.guns.sound.SoundManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@OnlyIn(Dist.CLIENT)
+@Mixin(targets = "com.tacz.guns.client.sound.SoundPlayManager")
+public class SoundPlayManagerMixin {
+
+    @Inject(method = "playShootSound", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void onPlayShootSound(LivingEntity entity, GunDisplayInstance gunIndex, GunData gunData, CallbackInfo ci) {
+        ItemStack gunItem = getGunItem(entity);
+        AmmoData ammoData = AmmoManager.getCurrentAmmoData(gunItem);
+        if (ammoData != null) {
+            float volume = 0.8f;
+            float pitchBase = 0.9f;
+            float pitchRandom = 0.125f;
+            int distance = (int) (GunConfig.DEFAULT_GUN_FIRE_SOUND_DISTANCE.get() * gunData.getFireSound().getFireMultiplier());
+
+            if (ammoData.getSoundVolume() != null) volume = ammoData.getSoundVolume();
+            if (ammoData.getSoundPitch() != null) {
+                pitchBase = 0.9f * ammoData.getSoundPitch();
+                pitchRandom = 0.125f * ammoData.getSoundPitch();
+            }
+            if (ammoData.getSoundDistanceMultiplier() != null) {
+                distance = Math.round(distance * ammoData.getSoundDistanceMultiplier());
+                if (distance < 0) distance = 0;
+            }
+
+            float pitch = pitchBase + entity.getRandom().nextFloat() * pitchRandom;
+            GunSoundInstance instance = new GunSoundInstance(
+                    ModSounds.GUN.get(),
+                    SoundSource.PLAYERS,
+                    volume,
+                    pitch,
+                    entity,
+                    distance,
+                    gunIndex.getSounds(SoundManager.SHOOT_SOUND),
+                    false
+            );
+            Minecraft.getInstance().getSoundManager().play(instance);
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "playSilenceSound", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void onPlaySilenceSound(LivingEntity entity, GunDisplayInstance gunIndex, GunData gunData, CallbackInfo ci) {
+        ItemStack gunItem = getGunItem(entity);
+        AmmoData ammoData = AmmoManager.getCurrentAmmoData(gunItem);
+        if (ammoData != null) {
+            float volume = 0.6f;
+            float pitchBase = 0.9f;
+            float pitchRandom = 0.125f;
+            int distance = (int) (GunConfig.DEFAULT_GUN_SILENCE_SOUND_DISTANCE.get() * gunData.getFireSound().getSilenceMultiplier());
+
+            if (ammoData.getSoundVolume() != null) volume = ammoData.getSoundVolume();
+            if (ammoData.getSoundPitch() != null) {
+                pitchBase = 0.9f * ammoData.getSoundPitch();
+                pitchRandom = 0.125f * ammoData.getSoundPitch();
+            }
+            if (ammoData.getSoundDistanceMultiplier() != null) {
+                distance = Math.round(distance * ammoData.getSoundDistanceMultiplier());
+                if (distance < 0) distance = 0;
+            }
+
+            float pitch = pitchBase + entity.getRandom().nextFloat() * pitchRandom;
+            GunSoundInstance instance = new GunSoundInstance(
+                    ModSounds.GUN.get(),
+                    SoundSource.PLAYERS,
+                    volume,
+                    pitch,
+                    entity,
+                    distance,
+                    gunIndex.getSounds(SoundManager.SILENCE_SOUND),
+                    false
+            );
+            Minecraft.getInstance().getSoundManager().play(instance);
+            ci.cancel();
+        }
+    }
+
+    private static ItemStack getGunItem(LivingEntity entity) {
+        if (entity instanceof net.minecraft.client.player.LocalPlayer player) {
+            return player.getMainHandItem();
+        }
+        return ItemStack.EMPTY;
+    }
+}

--- a/src/main/java/com/scarasol/tud/mixin/accessor/GunDataAccessor.java
+++ b/src/main/java/com/scarasol/tud/mixin/accessor/GunDataAccessor.java
@@ -2,9 +2,13 @@ package com.scarasol.tud.mixin.accessor;
 
 import com.tacz.guns.resource.pojo.data.gun.BulletData;
 import com.tacz.guns.resource.pojo.data.gun.GunData;
+import com.tacz.guns.resource.pojo.data.gun.GunRecoil;
+import com.tacz.guns.resource.pojo.data.gun.InaccuracyType;
 import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
 
 /**
  * @author Scarasol
@@ -25,4 +29,10 @@ public interface GunDataAccessor {
 
     @Accessor("ammoId")
     void tud$setAmmoId(ResourceLocation v);
+
+    @Accessor("inaccuracy")
+    Map<InaccuracyType, Float> tud$getInaccuracy();
+
+    @Accessor("inaccuracy")
+    void tud$setInaccuracy(Map<InaccuracyType, Float> inaccuracy);
 }

--- a/src/main/java/com/scarasol/tud/util/TaczGunDataOverrideUtil.java
+++ b/src/main/java/com/scarasol/tud/util/TaczGunDataOverrideUtil.java
@@ -9,11 +9,7 @@ import com.scarasol.tud.mixin.accessor.GunDataAccessor;
 import com.scarasol.tud.util.data.DataManager;
 import com.scarasol.tud.api.functional.EntityGetter;
 import com.scarasol.tud.manager.EntitySpawnManager;
-import com.tacz.guns.resource.pojo.data.gun.BulletData;
-import com.tacz.guns.resource.pojo.data.gun.ExplosionData;
-import com.tacz.guns.resource.pojo.data.gun.ExtraDamage;
-import com.tacz.guns.resource.pojo.data.gun.GunData;
-import com.tacz.guns.resource.pojo.data.gun.Ignite;
+import com.tacz.guns.resource.pojo.data.gun.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
@@ -22,6 +18,8 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.LinkedList;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class TaczGunDataOverrideUtil {
 
@@ -32,14 +30,16 @@ public final class TaczGunDataOverrideUtil {
 
     @Nullable
     public static GunData buildOverrideGunData(GunData originalGunData, ItemStack gunItem) {
-        AmmoData ammo = AmmoManager.getCurrentAmmoData(gunItem);
-        MagData mag = AmmoManager.getCurrentMagData(gunItem);
-
-        if (ammo == null && mag == null) {
+        if (originalGunData == null) {
             return null;
         }
 
-        // 只有当 ammo.isItem == false 时，才允许覆盖 ammoId，并且只用 ammoData 的 ammoId
+        AmmoData ammo = AmmoManager.getCurrentAmmoData(gunItem);
+        MagData mag = null;
+        com.scarasol.tud.data.GunData tudGunData = AmmoManager.getGunData(gunItem);
+        if (tudGunData != null) {
+            mag = tudGunData.getCurrentMag(gunItem);
+        }
         boolean ammoIdOverride = false;
         ResourceLocation desiredAmmoId = null;
         if (ammo != null && !ammo.isItem() && ammo.getAmmoId() != null) {
@@ -47,32 +47,44 @@ public final class TaczGunDataOverrideUtil {
             ammoIdOverride = desiredAmmoId != null
                     && (originalGunData.getAmmoId() == null || !desiredAmmoId.equals(originalGunData.getAmmoId()));
         }
-
         boolean ammoOverride = ammo != null && needOverride(ammo);
         boolean magOverride = mag != null && needOverride(mag);
 
         if (!ammoOverride && !magOverride && !ammoIdOverride) {
             return null;
         }
-
         GunData copy = shallowCopyGunData(originalGunData);
         if (copy == null) {
             return null;
         }
-
-        if (ammoIdOverride) {
-            ((GunDataAccessor) (Object) copy).tud$setAmmoId(desiredAmmoId);
+        float accuracyModifier = 1.0f;
+        if (ammo != null && ammo.getAccuracyModifier() != null) {
+            accuracyModifier *= ammo.getAccuracyModifier();
         }
-
+        if (mag != null) {
+            accuracyModifier *= mag.getAccuracyModifier();
+        }
+        if (Math.abs(accuracyModifier - 1.0f) > 0.0001f) {
+            Map<InaccuracyType, Float> originalMap = copy.getInaccuracy();
+            if (originalMap != null && !originalMap.isEmpty()) {
+                Map<InaccuracyType, Float> newMap = new HashMap<>();
+                for (Map.Entry<InaccuracyType, Float> entry : originalMap.entrySet()) {
+                    newMap.put(entry.getKey(), entry.getValue() * accuracyModifier);
+                }
+                copy.setInaccuracy(newMap);
+            }
+        }
+        if (ammoIdOverride) {
+            ((GunDataAccessor) copy).tud$setAmmoId(desiredAmmoId);
+        }
         if (magOverride) {
             applyMagOverrides(copy, mag);
         }
-
         if (ammoOverride) {
             BulletData srcBullet = originalGunData.getBulletData();
             if (srcBullet != null) {
                 BulletData bulletCopy = buildBulletCopy(srcBullet, ammo);
-                ((GunDataAccessor) (Object) copy).tud$setBulletData(bulletCopy);
+                ((GunDataAccessor) copy).tud$setBulletData(bulletCopy);
             }
         }
 
@@ -98,7 +110,8 @@ public final class TaczGunDataOverrideUtil {
                 || ammo.getExplosionDelayCount() != null
                 || ammo.getArmorIgnore() != null
                 || ammo.getHeadShot() != null
-                || (ammo.getDamageAdjust() != null && !ammo.getDamageAdjust().isEmpty());
+                || (ammo.getDamageAdjust() != null && !ammo.getDamageAdjust().isEmpty())
+                || ammo.getBulletAmount() != null;
     }
 
     private static boolean needOverride(MagData mag) {
@@ -206,6 +219,15 @@ public final class TaczGunDataOverrideUtil {
         if (ammo.getPierce() != null) {
             b.tud$setPierce(Math.max(1, ammo.getPierce()));
         }
+        if (ammo.getBulletAmount() != null) {
+            int amount = Math.max(1, ammo.getBulletAmount());
+            b.tud$setBulletAmount(amount);
+        }
+
+        applyExtraDamage(b, srcBullet, ammo);
+        applyIgnite(b, srcBullet, ammo);
+        applyExplosion(b, srcBullet, ammo);
+        applyTracer(b, ammo);
 
         applyExtraDamage(b, srcBullet, ammo);
         applyIgnite(b, srcBullet, ammo);

--- a/src/main/resources/assets/tacz_unidict/lang/en_us.json
+++ b/src/main/resources/assets/tacz_unidict/lang/en_us.json
@@ -9,5 +9,8 @@
     "tacz_unidict.ammo.rifle.name": "General Rifle",
     "tacz_unidict.ammo.shot.name": "General Shot",
     "tacz_unidict.ammo.sniper.name": "General Sniper",
-    "tacz_unidict.gun.ammo.desc": "Tacz: Unidict"
+    "tacz_unidict.gun.ammo.desc": "Tacz: Unidict",
+
+    "tacz_unidict.tooltip.damage_per_projectile": "Damage:",
+    "tacz_unidict.tooltip.damage_single": "Damage:"
 }

--- a/src/main/resources/assets/tacz_unidict/lang/zh_cn.json
+++ b/src/main/resources/assets/tacz_unidict/lang/zh_cn.json
@@ -9,5 +9,8 @@
     "tacz_unidict.ammo.rifle.name": "通用步枪子弹",
     "tacz_unidict.ammo.shot.name": "通用霰弹",
     "tacz_unidict.ammo.sniper.name": "通用狙击枪子弹",
-    "tacz_unidict.gun.ammo.desc": "通用子弹"
+    "tacz_unidict.gun.ammo.desc": "通用子弹",
+
+    "tacz_unidict.tooltip.damage_per_projectile": "伤害:",
+    "tacz_unidict.tooltip.damage_single": "伤害:"
 }

--- a/src/main/resources/tud.mixins.json
+++ b/src/main/resources/tud.mixins.json
@@ -21,11 +21,11 @@
     "accessor.BulletDataAccessor",
     "accessor.ExtraDamageAccessor",
     "accessor.FallingBlockEntityAccessor",
-    "accessor.GunDataAccessor",
-    "GunRecoilMixin"
+    "accessor.GunDataAccessor"
   ],
   "client": [
     "LocalPlayerShootMixin",
-    "SoundPlayManagerMixin"
+    "SoundPlayManagerMixin",
+    "GunRecoilMixin"
   ]
 }

--- a/src/main/resources/tud.mixins.json
+++ b/src/main/resources/tud.mixins.json
@@ -21,8 +21,11 @@
     "accessor.BulletDataAccessor",
     "accessor.ExtraDamageAccessor",
     "accessor.FallingBlockEntityAccessor",
-    "accessor.GunDataAccessor"
+    "accessor.GunDataAccessor",
+    "GunRecoilMixin"
   ],
   "client": [
+    "LocalPlayerShootMixin",
+    "SoundPlayManagerMixin"
   ]
 }


### PR DESCRIPTION
## 主要新增功能

1. **弹丸数量**  
   - 允许为每种弹药单独配置弹丸数量，超过 1 时会在工具提示中显示“总伤害 ÷ 弹丸数 × 弹丸数”的格式。

2. **声音控制**  
   - 支持为弹药配置文件自定义 **音量系数**、**音高系数**、**强制消音**、**声音传播距离系数**。  
   - 通过混入 `SoundPlayManager` 实现，音量、音高、消音效果均已在客户端本地生效。

3. **后坐力系数**  
   - 在弹药和枪械配置中分别添加 **水平后坐力乘数** 与 **垂直后坐力乘数**。  
   - 通过混入 `GunRecoil.genPitchSplineFunction` / `genYawSplineFunction`，将乘数直接应用到后坐力生成函数中，可叠加配件效果。

4. **伤害修正值**  
   - 在枪械配置（`MagData`）中添加 `damageBonus` 字段，表示每发子弹的固定伤害加减值。  
   - 命中时动态修改 `EntityHurtByGunEvent.Pre` 的伤害值，同时工具提示中的伤害数值会同步更新（在多个弹丸时增加的伤害修正会应用到每个弹丸上）。

5. **精确度系数**  
   - 在弹药和枪械配置中分别添加 **精确度乘数**（默认 1.0）。  
   - 通过混入 `GunData.inaccuracy` 的覆写，将乘数应用到所有射击姿势下的散布值（值越小子弹越集中）。  
   - 支持弹药级与枪械级的乘算叠加。

## 测试情况

- 在 1.20.1 Forge 环境、TACZ 1.1.7+ 下测试通过。  
- 弹丸数量、声音、后坐力、伤害修正、精确度系数均能按配置生效，但未进行多人游戏测试。  
- 未发现明显性能损耗或与原版配件系统的冲突。